### PR TITLE
Update README with BigQuery tutorial and free quota details

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 This project maintains an archive of Jamulus users who have connected to public Jamulus servers. The dataset is available in BigQuery at `dtinth-storage-space.jamulus.clients`.
 
+## Getting Started with BigQuery
+
+To query the Jamulus User Public Dataset using BigQuery, follow these steps:
+
+1. Visit the [Google Cloud Console](https://console.cloud.google.com/).
+2. Create a new project or select an existing project.
+3. Navigate to the BigQuery service.
+4. Use the BigQuery web UI to write and execute your SQL queries.
+
+You can find more detailed instructions and examples in the [BigQuery documentation](https://cloud.google.com/bigquery/docs).
+
+BigQuery offers a free quota that allows you to query up to 1 TB of data per month for free. This makes it easy to explore and analyze the Jamulus User Public Dataset without any cost. Additionally, you can try BigQuery without needing a credit card for the free quota.
+
 ## Example queries
 
 Query the date range of the dataset:


### PR DESCRIPTION
Updates the README.md file to enhance guidance on using BigQuery with the Jamulus User Public Dataset.

- **Adds a tutorial**: Introduces a "Getting Started with BigQuery" section that provides a step-by-step guide for querying the dataset using BigQuery, making it more accessible for beginners.
- **Includes documentation link**: Adds a link to the BigQuery documentation for users seeking further information and examples.
- **Mentions free quota**: Details BigQuery's free quota, specifying that users can query up to 1 TB of data per month for free, encouraging users to explore the dataset without worrying about costs.
- **Highlights no credit card requirement**: Clarifies that users can try BigQuery without needing a credit card for the free quota, lowering the barrier for new users to start experimenting with the dataset.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dtinth/jamulus-archive?shareId=56890e7e-1b00-4571-9749-c5593c766711).